### PR TITLE
Correct Class Definitions

### DIFF
--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -9,9 +9,9 @@
 #  Array of alerts (see README)
 #
 class prometheus::alerts (
-  String $location,
-  Array  $alerts,
-  String $alertfile_name  = 'alert.rules'
+  $location        = $::prometheus::params::alertmanager_config_dir,
+  $alerts          = [],
+  $alertfile_name  = 'alert.rules'
 ) inherits prometheus::params {
 
     if $alerts != [] {


### PR DESCRIPTION
We are observing the following error when initially configuring alertmanager with the updated module...

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at 'String'; expected ')' at /puppet/src/environments/production/modules/prometheus/manifests/alerts.pp:12 on node redacted.example.net 
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

Basically this is an issue with the class definition for alerts and seems pretty easily fixed since defaults are all defined anyway...

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
